### PR TITLE
Kmer search optimizations

### DIFF
--- a/src/genome_compare.c
+++ b/src/genome_compare.c
@@ -1,6 +1,7 @@
 #include <zlib.h>
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include "kseq.h"
 #include "BIO_sequence.h"
 #include "BIO_hash.h"
@@ -184,10 +185,11 @@ void GEN_calculate_kmer_count(const char *file, const int seed, BIO_hash h, unsi
 	char *orientStr;
 	unsigned int *count = NULL;
 	unsigned int seq_count = 0;
-	seedStrRevComp[seed] = '\0';
 	char temp_nuc;
 	char *seed_seq;
 	int enough_reads = 0;
+	int has_N;
+
 
 	fp = gzopen(file, "r");
 	if (fp == NULL) {
@@ -199,28 +201,32 @@ void GEN_calculate_kmer_count(const char *file, const int seed, BIO_hash h, unsi
 //	printf("%s\n", file);
 
 	while (l = kseq_read(seq) >= 0) {
+		if (seq->seq.l >= seed) { // skip if a read has been trimmed shorter than the seed length
 //	while (!enough_reads && (l = kseq_read(seq)) >= 0) {
 //		if (max_reads && seq_count++ > max_reads)
 //			enough_reads = 1;
-		BIO_stringToUpper(seq->seq.s); // keep same case
-		seed_seq = seq->seq.s;
+			BIO_stringToUpper(seq->seq.s); // keep same case
+			seed_seq = seq->seq.s;
+			has_N = contains_N(seed_seq);
 
-		for (i = 0; i<seq->seq.l - seed+1; i++) { // for each possible seed position
-			temp_nuc = seed_seq[seed];
-			seed_seq[seed] = '\0';	
+	
+			for (i = 0; i<seq->seq.l - seed+1; i++) { // for each possible seed position
+				temp_nuc = seed_seq[seed];
+				seed_seq[seed] = '\0';	
 
-			orientStr = orient_string(seed_seq, seedStrRevComp, seed);
-
-			if (!contains_N(orientStr)) {
-				count = (unsigned int*)BIO_searchHash(h,orientStr);
-				if (count != NULL) {
-					count[vec_column]+=1; // increment the n-mer
-				}
-
-			} 
-
-			seed_seq[seed] = temp_nuc;
-			seed_seq++;
+				orientStr = orient_string(seed_seq, seedStrRevComp, seed);
+	
+				if (!has_N || !contains_N(orientStr)) {
+					count = (unsigned int*)BIO_searchHash(h,orientStr);
+					if (count != NULL) {
+						count[vec_column]+=1; // increment the n-mer
+					}
+	
+				} 
+	
+				seed_seq[seed] = temp_nuc;
+				seed_seq++;
+			}
 		}
 	}
 

--- a/src/genome_compare.c
+++ b/src/genome_compare.c
@@ -1111,8 +1111,6 @@ char* orient_string(char *seed_seq, char *seedStrRevComp, int seed) {
 //		printf("%s\trc\n", seedStrRevComp);
 		return seedStrRevComp;
 	}
-		
-
 }
 
 int rc_strcmp(char *seed_seq, int seed) {

--- a/src/strain_detect.c
+++ b/src/strain_detect.c
@@ -383,13 +383,15 @@ void quantify_hits_all_files(const char *file_of_filenames, const char *file_PE1
         BIO_destroyHashKeys(allKeys);
 }
 
+/* this is where we spend most of the CPU time; have done quite a lot of optimization to speed up; major bottleneck is the hash; trying to improve that next... */
 void quantify_hits_PE(const char *PE1_file, const char *PE2_file, BIO_hash h, const int seed, FILE *out, gzFile *gzout, int hash_size, const int is_PE, const unsigned int genome_kmers, const unsigned int genome_informative_kmers) {
 	gzFile fp;
 	gzFile fp2 = NULL;
 	kseq_t *seq, *seq2;
 	int l, l2;
 	unsigned int i;
-	char *seedStrRevComp = (char*)malloc(sizeof(char) * seed+1);
+//	char *seedStrRevComp = (char*)malloc(sizeof(char) * seed+1);
+	char *seedStrRevComp = (char*)malloc(sizeof(char) * 10000);
 	char *sequence_PE1_copy = (char*)malloc(sizeof(char) * 10000);
 	int sequence_PE1_length = 0;
 	char *orientStr;
@@ -406,6 +408,7 @@ void quantify_hits_PE(const char *PE1_file, const char *PE2_file, BIO_hash h, co
 	int total_read_informative_kmer_hits = 0;
 	long long unsigned int total_kmers_evaluated = 0;
 	long long unsigned int total_reads_evaluated = 0;
+	int has_N;
 //	int min_hits_for_informative_read = 5;
 //	int min_hits_for_good_match = 5;
 //	int min_hits_for_informative_read = 10;
@@ -436,25 +439,42 @@ void quantify_hits_PE(const char *PE1_file, const char *PE2_file, BIO_hash h, co
 
 //	fprintf(stderr, "reading %s to check in hash %d\n", PE1, BIO_getHashSize(h));
 
+	char *seed_seq_rc;
 	while (l = kseq_read(seq) >= 0) {
-		read_kmer_hits = 0;
-		read_informative_kmer_hits = 0;
-		BIO_stringToUpper(seq->seq.s); // keep same case
-		seed_seq = seq->seq.s;
-
-		// need to copy this stuff because in interleaved files it is forgotten when I read the next one
-		strcpy(sequence_PE1_copy, seq->seq.s);
-		sequence_PE1_length = seq->seq.l;
-		total_reads_evaluated++;
-
-		/* do PE1 */
 		if (seq->seq.l >= seed) { // skip if a read has been trimmed shorter than the seed length
+			total_reads_evaluated++;
+			read_kmer_hits = 0;
+			read_informative_kmer_hits = 0;
+			sequence_PE1_length = seq->seq.l;
+			BIO_stringToUpper(seq->seq.s); // keep same case
+
+			seed_seq = seq->seq.s;
+
+			// need to copy this stuff because in interleaved files it is forgotten when I read the next one
+			strcpy(sequence_PE1_copy, seq->seq.s);
+
+			// make the reverse complement now so that we can move along the string using pointers and avoid complementing substrings over and over
+			strcpy(seedStrRevComp, seq->seq.s);
+			BIO_reverseComplement(seedStrRevComp);
+			seed_seq_rc = &seedStrRevComp[sequence_PE1_length-seed];
+
+			/* do PE1 */
+
+			has_N = contains_N(seed_seq);
+
 			for (i = 0; i<seq->seq.l - seed+1; i++) { // for each possible seed position
 				temp_nuc = seed_seq[seed];
 				seed_seq[seed] = '\0';
+				seed_seq_rc[seed] = '\0';
+//				printf("%s\n%s\n\n", seed_seq, seedStrRevComp);
+				//if (total_reads_evaluated == 10) { exit(0);}
+                                if (strcmp(seed_seq, seed_seq_rc) > 0) //  orient the strings doing the upfront revcomp with pointer shifts is slightly faster than the orient_string function
+                                        orientStr = seed_seq;
+                                else
+                                        orientStr = seed_seq_rc;
 	
-				orientStr = orient_string(seed_seq, seedStrRevComp, seed);
-				if (!contains_N(orientStr)) {
+//				orientStr = orient_string(seed_seq, seedStrRevComp, seed);
+				if (!has_N || !contains_N(orientStr)) {
 					count = (unsigned int*)BIO_searchHash(h,orientStr);
 					if (count != NULL) {
 //						*count+=1; // increment the n-mer
@@ -466,29 +486,43 @@ void quantify_hits_PE(const char *PE1_file, const char *PE2_file, BIO_hash h, co
 	
 				seed_seq[seed] = temp_nuc;
 				seed_seq++;
+				seed_seq_rc--;
 				total_kmers_evaluated++;
 			}
 		}
 
 		/* do PE2 */
 		if (is_PE) {
-			read_kmer_hits_pe2 = 0;
-			read_informative_kmer_hits_pe2 = 0;
 			l2 = kseq_read(seq2);
-			if (l2 < 0) {
-				fprintf(stderr, "reached end of PE2 (%s) before end of PE1 (%s), check that file names are correct\n", PE2_file, PE1_file);
-				exit(EXIT_FAILURE);
-			}
-			BIO_stringToUpper(seq2->seq.s); // keep same case
-			seed_seq = seq2->seq.s;
-
 			if (seq2->seq.l >= seed) { // skip if a read has been trimmed shorter than the seed length
+
+				read_kmer_hits_pe2 = 0;
+				read_informative_kmer_hits_pe2 = 0;
+				if (l2 < 0) {
+					fprintf(stderr, "reached end of PE2 (%s) before end of PE1 (%s), check that file names are correct\n", PE2_file, PE1_file);
+					exit(EXIT_FAILURE);
+				}
+				BIO_stringToUpper(seq2->seq.s); // keep same case
+				seed_seq = seq2->seq.s;
+				has_N = contains_N(seed_seq);
+
+				// make the reverse complement now so that we can move along the string using pointers and avoid complementing substrings over and over
+				strcpy(seedStrRevComp, seq2->seq.s);
+				BIO_reverseComplement(seedStrRevComp);
+				seed_seq_rc = &seedStrRevComp[seq2->seq.l - seed];
+
 				for (i = 0; i<seq2->seq.l - seed+1; i++) { // for each possible seed position
 					temp_nuc = seed_seq[seed];
 					seed_seq[seed] = '\0';
+					seed_seq_rc[seed] = '\0';
 		
-					orientStr = orient_string(seed_seq, seedStrRevComp, seed);
-					if (!contains_N(orientStr)) {
+				//	orientStr = orient_string(seed_seq, seedStrRevComp, seed);
+                                	if (strcmp(seed_seq, seed_seq_rc) > 0) //  orient the strings doing the upfront revcomp with pointer shifts is slightly faster than the orient_string function
+                                	        orientStr = seed_seq;
+                                	else
+                                	        orientStr = seed_seq_rc;
+
+					if (!has_N || !contains_N(orientStr)) {
 						count = (unsigned int*)BIO_searchHash(h,orientStr);
 						if (count != NULL) {
 //							*count+=1; // increment the n-mer
@@ -500,6 +534,7 @@ void quantify_hits_PE(const char *PE1_file, const char *PE2_file, BIO_hash h, co
 		
 					seed_seq[seed] = temp_nuc;
 					seed_seq++;
+					seed_seq_rc--;
 					total_kmers_evaluated++;
 				}
 			}


### PR DESCRIPTION
1. fine tuning on the most CPU intensive parts of the kmer scrubbing and strain detect counting steps. these are mainly caching some steps on the full sequencing read so they don't need to be done repeatedly on the substrings (i.e., the kmers). Result is ~50% improvement 
2. this tuning revealed a bug in the kmer_scrub_count program that is the same as @watsonar previously found in the strain_detect program (where reads <kmer_length led to memory crash). this is the main reason for the pull request, as I'd like to get this bug fix out into main branch.

more optimizations to come. going to try: 1) faster hash function; 2) tie in kmer_scrub_count with kmc3 database. both of these are a little more work than the low hanging fruit above.